### PR TITLE
Animation Editor fixes & additions

### DIFF
--- a/RetroEDv2/tools/animationeditor.hpp
+++ b/RetroEDv2/tools/animationeditor.hpp
@@ -93,6 +93,8 @@ private:
     bool mouseDownM = false;
     bool mouseDownR = false;
 
+    bool savedPivToggle = false;
+
     Vector2<int> offset = Vector2<int>(0, 0);
 
     QPoint reference;

--- a/RetroEDv2/tools/animationeditor.ui
+++ b/RetroEDv2/tools/animationeditor.ui
@@ -116,6 +116,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="frameOffReset">
+        <property name="text">
+         <string>Reset Offset</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="zoomLabel">
         <property name="text">
          <string>Zoom: 100%</string>
@@ -138,6 +145,16 @@
         </property>
         <property name="autoRaise">
          <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="bgColorRemove">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Remove BG Color</string>
         </property>
        </widget>
       </item>
@@ -777,7 +794,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="animPage">
       <property name="geometry">
@@ -785,7 +802,7 @@
         <x>0</x>
         <y>0</y>
         <width>300</width>
-        <height>307</height>
+        <height>294</height>
        </rect>
       </property>
       <attribute name="label">
@@ -980,8 +997,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>283</width>
-        <height>438</height>
+        <width>286</width>
+        <height>492</height>
        </rect>
       </property>
       <attribute name="label">
@@ -1485,7 +1502,7 @@
         <x>0</x>
         <y>0</y>
         <width>300</width>
-        <height>307</height>
+        <height>294</height>
        </rect>
       </property>
       <attribute name="label">
@@ -1611,7 +1628,7 @@
         <x>0</x>
         <y>0</y>
         <width>300</width>
-        <height>307</height>
+        <height>294</height>
        </rect>
       </property>
       <attribute name="label">

--- a/RetroEDv2/tools/animationeditor/animsheetselector.cpp
+++ b/RetroEDv2/tools/animationeditor/animsheetselector.cpp
@@ -8,7 +8,7 @@
 #include "dependencies/imageviewer/src/image-viewer.h"
 #include <QTimer>
 
-AnimSheetSelector::AnimSheetSelector(QString sheetPath, QImage *sheet, QWidget *parent)
+AnimSheetSelector::AnimSheetSelector(QString sheetPath, QImage *sheet, bool toggle, QWidget *parent)
     : QDialog(parent), ui(new Ui::AnimSheetSelector), sheetPath(sheetPath), sheet(sheet)
 {
     ui->setupUi(this);
@@ -28,6 +28,7 @@ AnimSheetSelector::AnimSheetSelector(QString sheetPath, QImage *sheet, QWidget *
         bgColor = this->sheet->colorTable().last();
     }
 
+    ui->pivotToggle->setChecked(toggle);
     QPalette pal(bgColor);
     ui->colorButton->setPalette(pal);
 
@@ -42,6 +43,10 @@ AnimSheetSelector::AnimSheetSelector(QString sheetPath, QImage *sheet, QWidget *
 
     connect(ui->buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(ui->buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    connect(ui->pivotToggle, &QCheckBox::clicked, [this](){
+        pivotToggle = ui->pivotToggle->isChecked();
+    });
 
     connect(viewer->pixmapItem(), &pal::PixmapItem::mouseDownR, [this, viewer](int x, int y) {
         bgColor = this->sheet->pixelColor(x, y);

--- a/RetroEDv2/tools/animationeditor/animsheetselector.hpp
+++ b/RetroEDv2/tools/animationeditor/animsheetselector.hpp
@@ -12,10 +12,11 @@ class AnimSheetSelector : public QDialog
     Q_OBJECT
 
 public:
-    explicit AnimSheetSelector(QString sheetPath, QImage *sheet, QWidget *parent = nullptr);
+    explicit AnimSheetSelector(QString sheetPath, QImage *sheet, bool toggle = false, QWidget *parent = nullptr);
     ~AnimSheetSelector();
 
     Rect<int> returnRect = Rect<int>(-1, -1, -1, -1);
+    bool pivotToggle = false;
 
 protected:
     void changeEvent(QEvent *e);

--- a/RetroEDv2/tools/animationeditor/animsheetselector.ui
+++ b/RetroEDv2/tools/animationeditor/animsheetselector.ui
@@ -31,31 +31,6 @@
    </property>
    <item row="1" column="0">
     <layout class="QGridLayout" name="gridLayout_2">
-     <item row="3" column="2">
-      <widget class="QDialogButtonBox" name="buttons">
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="borderLabel">
-       <property name="text">
-        <string>Border color:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0" colspan="3">
-      <widget class="QFrame" name="viewerFrame">
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Raised</enum>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_4"/>
-      </widget>
-     </item>
      <item row="3" column="1">
       <widget class="QToolButton" name="colorButton">
        <property name="mouseTracking">
@@ -69,6 +44,41 @@
        </property>
        <property name="text">
         <string notr="true"/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="4">
+      <widget class="QFrame" name="viewerFrame">
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4"/>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="borderLabel">
+       <property name="text">
+        <string>Border color:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="QDialogButtonBox" name="buttons">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QCheckBox" name="pivotToggle">
+       <property name="layoutDirection">
+        <enum>Qt::RightToLeft</enum>
+       </property>
+       <property name="text">
+        <string>Disable pivot adjust</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
* Adds toggle to disable pivot modifications when selecting bounding box.
* Adds buttons to reset camera offset and removal of BG color.
* Pre-v5 Hitboxes values for 'LWall' 'Roof' and 'RWall' are now based on Outer box and Inner box rather than being based on the previous 'LWall' 'Roof' and 'RWall' hitbox value (fixes values on new hitboxes being 0, essentially making them unusable on angular tiles)
* Hitboxes can now be moved on v3/v4 without crashing the editor
* Hitboxes and sheets need to be selected before being able to move them, preventing crashes
* 'Import Source' can now read BMP files if the ani version is v1
* Commented out some debug PrintLogs that were clogging up the console