### PR TITLE
Fixed GameConfig Not Loading Between v5 Scene Loads

### DIFF
--- a/RetroEDv2/tools/sceneeditorv5.cpp
+++ b/RetroEDv2/tools/sceneeditorv5.cpp
@@ -1601,9 +1601,9 @@ bool SceneEditorv5::event(QEvent *event)
                 QString gcPath = "";
 
                 QString filePath = QFileInfo(filedialog.selectedFiles()[0]).absolutePath();
-                QDir dir(filePath); // Data/Stages/SCENE/
-                dir.cdUp();         // Data/Stages/
-                dir.cdUp();         // Data/
+                QDir dir(filePath); // Data/Stages/SCENE
+                dir.cdUp();         // Data/Stages
+                dir.cdUp();         // Data
 
                 if (dataPath.isEmpty() || dataPath != dir.path()) {
                     QFileDialog gcdialog(
@@ -1619,6 +1619,10 @@ bool SceneEditorv5::event(QEvent *event)
                         }
                         gcPath = gameConfig.filePath;
                     }
+                }
+                else {
+                    // Same data path, reuse game config
+                    gcPath = gameConfig.filePath;
                 }
 
                 LoadScene(filedialog.selectedFiles()[0], gcPath, filter);


### PR DESCRIPTION
This PR fixes #82 by reusing the game config path if a data path is already set, otherwise objects will not load when loading a new scene. 