### PR TITLE
Fix SceneViewer FPS counter and remove update cap

### DIFF
--- a/RetroEDv2/tools/sceneviewer.hpp
+++ b/RetroEDv2/tools/sceneviewer.hpp
@@ -83,7 +83,9 @@ public:
     bool disableObjects   = true;
     bool disableDrawScene = false;
 
-    double fps;
+    int updateCount = 0;
+    double sumFps = 0.0;
+    double avgFps = 0.0;
     QElapsedTimer fpsTimer;
 
     byte gameType = ENGINE_NONE;


### PR DESCRIPTION
Make the FPS counter actually count the average framerate instead of draw time (counter is averaged over a second of runtime). Remove the 60FPS timer to make it update as fast as possible.
Since the OpenGL context has VSync enabled, the scene will cap at the screen's refresh rate.