### PR TITLE
Scene Editor PR

### DIFF
--- a/RetroEDv2/tools/sceneeditor.cpp
+++ b/RetroEDv2/tools/sceneeditor.cpp
@@ -468,10 +468,8 @@ SceneEditor::SceneEditor(QWidget *parent) : QWidget(parent), ui(new Ui::SceneEdi
 
         viewer->selectedEntity = n;
 
-        auto *entity = &viewer->entities[viewer->selectedEntity];
-
-
         if (n != -1){
+            auto *entity = &viewer->entities[viewer->selectedEntity];
             viewer->cameraPos.x = viewer->entities[n].pos.x - ((viewer->storedW / 2) * viewer->invZoom());
             viewer->cameraPos.y = viewer->entities[n].pos.y - ((viewer->storedH / 2) * viewer->invZoom());
 
@@ -480,6 +478,12 @@ SceneEditor::SceneEditor(QWidget *parent) : QWidget(parent), ui(new Ui::SceneEdi
                              &compilerv3->objectEntityList[entity->gameEntitySlot],
                              &compilerv4->objectEntityList[entity->gameEntitySlot], viewer->gameType);
             ui->propertiesBox->setCurrentWidget(ui->objPropPage);
+
+            for (int s = n; s < viewer->selectedEntities.count(); ++s) {
+                if (viewer->selectedEntities[s] == (int)c)
+                    viewer->selectedEntities[s] = c - 1;
+                viewer->entities[s].slotID = viewer->entities[s - 1].slotID;
+            }
         }
 
         ui->horizontalScrollBar->blockSignals(true);
@@ -489,12 +493,6 @@ SceneEditor::SceneEditor(QWidget *parent) : QWidget(parent), ui(new Ui::SceneEdi
         ui->verticalScrollBar->blockSignals(true);
         ui->verticalScrollBar->setValue(viewer->cameraPos.y);
         ui->verticalScrollBar->blockSignals(false);
-
-        for (int s = n; s < viewer->selectedEntities.count(); ++s) {
-            if (viewer->selectedEntities[s] == (int)c)
-                viewer->selectedEntities[s] = c - 1;
-            viewer->entities[s].slotID = viewer->entities[s - 1].slotID;
-        }
 
         ui->rmEnt->setDisabled(viewer->entities.count() <= 0);
         ui->addEnt->setDisabled(viewer->entities.count() >= FormatHelpers::Scene::entityLimit);

--- a/RetroEDv2/tools/sceneeditor.cpp
+++ b/RetroEDv2/tools/sceneeditor.cpp
@@ -1276,6 +1276,7 @@ SceneEditor::SceneEditor(QWidget *parent) : QWidget(parent), ui(new Ui::SceneEdi
 
         connect(chunkRpl, &QDialog::finished, [this] {
             if (chunkRpl->modified){
+                chunkset = viewer->chunkset;
                 chkProp->RefreshList();
                 DoAction();
             }

--- a/RetroEDv2/tools/sceneeditor.hpp
+++ b/RetroEDv2/tools/sceneeditor.hpp
@@ -167,7 +167,7 @@ signals:
     void TitleChanged(QString title, QString tabFullPath);
 
 public slots:
-    void updateType(SceneEntity *entity, byte type);
+    void updateType(SceneEntity *entity, byte type, bool keepVals = false);
 protected:
     bool event(QEvent *event);
     bool eventFilter(QObject *object, QEvent *event);
@@ -178,9 +178,13 @@ private:
         COPY_LAYER,
         COPY_CHUNK,
         COPY_ENTITY,
+        COPY_ENTITY_SELECT,
         COPY_SCROLLINFO,
     };
     void *clipboard    = nullptr;
+    QList<int> clipboardIDs;
+    QList<Vector2<float>> clipboardOffset;
+    Vector2<float> clipPosCenter;
     byte clipboardType = COPY_NONE;
     int clipboardInfo  = 0;
 

--- a/RetroEDv2/tools/sceneeditor.ui
+++ b/RetroEDv2/tools/sceneeditor.ui
@@ -23,7 +23,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="layerPage">
       <property name="geometry">
@@ -139,23 +139,24 @@
        <string>Entity List</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
-       <item row="0" column="0" colspan="6">
+       <item row="1" column="0" colspan="6">
         <widget class="QListWidget" name="entityList"/>
        </item>
-       <item row="2" column="1">
-        <spacer name="horizontalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+       <item row="3" column="3">
+        <widget class="QToolButton" name="downEnt">
+         <property name="toolTip">
+          <string>Moves an entity down</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
+         <property name="text">
+          <string>D</string>
          </property>
-        </spacer>
+         <property name="icon">
+          <iconset resource="../resources.qrc">
+           <normaloff>:/icons/ic_arrow_downward_48px.svg</normaloff>:/icons/ic_arrow_downward_48px.svg</iconset>
+         </property>
+        </widget>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QToolButton" name="addEnt">
          <property name="toolTip">
           <string>Adds an entity</string>
@@ -169,7 +170,54 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="5">
+       <item row="3" column="2">
+        <widget class="QToolButton" name="upEnt">
+         <property name="toolTip">
+          <string>Moves an entity up</string>
+         </property>
+         <property name="text">
+          <string>U</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../resources.qrc">
+           <normaloff>:/icons/ic_arrow_upward_48px.svg</normaloff>:/icons/ic_arrow_upward_48px.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="6">
+        <widget class="QLineEdit" name="entityFilter">
+         <property name="placeholderText">
+          <string>Find entities...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <spacer name="horizontalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="3" column="4">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="3" column="5">
         <widget class="QToolButton" name="rmEnt">
          <property name="enabled">
           <bool>false</bool>
@@ -186,51 +234,10 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="3">
-        <widget class="QToolButton" name="downEnt">
-         <property name="toolTip">
-          <string>Moves an entity down</string>
-         </property>
+       <item row="0" column="0" colspan="6">
+        <widget class="QLabel" name="totalEntCount">
          <property name="text">
-          <string>D</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../resources.qrc">
-           <normaloff>:/icons/ic_arrow_downward_48px.svg</normaloff>:/icons/ic_arrow_downward_48px.svg</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QToolButton" name="upEnt">
-         <property name="toolTip">
-          <string>Moves an entity up</string>
-         </property>
-         <property name="text">
-          <string>U</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../resources.qrc">
-           <normaloff>:/icons/ic_arrow_upward_48px.svg</normaloff>:/icons/ic_arrow_upward_48px.svg</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="4">
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="0" colspan="6">
-        <widget class="QLineEdit" name="entityFilter">
-         <property name="placeholderText">
-          <string>Find entities...</string>
+          <string>Total Entity Count</string>
          </property>
         </widget>
        </item>

--- a/RetroEDv2/tools/sceneeditorv5.cpp
+++ b/RetroEDv2/tools/sceneeditorv5.cpp
@@ -839,6 +839,12 @@ SceneEditorv5::SceneEditorv5(QWidget *parent) : QWidget(parent), ui(new Ui::Scen
             viewer->cameraPos.y = viewer->entities[n].pos.y - ((viewer->storedH / 2) * viewer->invZoom());
             objProp->setupUI(&viewer->entities[n]);
             ui->propertiesBox->setCurrentWidget(ui->objPropPage);
+
+            for (int s = n; s < viewer->selectedEntities.count(); ++s) {
+                if (viewer->selectedEntities[s] == (int)c)
+                    viewer->selectedEntities[s] = c - 1;
+                viewer->entities[s].slotID = viewer->entities[s - 1].slotID;
+            }
         }
 
         ui->horizontalScrollBar->blockSignals(true);
@@ -848,13 +854,6 @@ SceneEditorv5::SceneEditorv5(QWidget *parent) : QWidget(parent), ui(new Ui::Scen
         ui->verticalScrollBar->blockSignals(true);
         ui->verticalScrollBar->setValue(viewer->cameraPos.y);
         ui->verticalScrollBar->blockSignals(false);
-
-        for (int s = n; s < viewer->selectedEntities.count(); ++s) {
-            if (viewer->selectedEntities[s] == (int)c)
-                viewer->selectedEntities[s] = c - 1;
-            viewer->entities[s].slotID = viewer->entities[s - 1].slotID;
-        }
-
         ui->rmEnt->setDisabled(viewer->entities.count() <= 0);
         ui->addEnt->setDisabled(viewer->activeEntityCount() >= SCENEENTITY_COUNT_v5);
         DoAction("Remove Entity: " + QString::number(c));

--- a/RetroEDv2/tools/sceneeditorv5.hpp
+++ b/RetroEDv2/tools/sceneeditorv5.hpp
@@ -159,7 +159,7 @@ signals:
     void TitleChanged(QString title, QString tabFullPath);
 
 public slots:
-    void updateType(SceneEntity *entity, byte type);
+    void updateType(SceneEntity *entity, byte type, bool keepVals = false);
     void updateStampName(QString name);
     void updateLayer(QString name);
     void updateTileSel();
@@ -174,9 +174,13 @@ private:
         COPY_LAYER,
         COPY_TILE,
         COPY_ENTITY,
+        COPY_ENTITY_SELECT,
         COPY_SCROLLINFO,
     };
     void *clipboard    = nullptr;
+    QList<int> clipboardIDs;
+    QList<Vector2<float>> clipboardOffset;
+    Vector2<float> clipPosCenter;
     byte clipboardType = COPY_NONE;
     int clipboardInfo  = 0;
 

--- a/RetroEDv2/tools/sceneeditorv5.ui
+++ b/RetroEDv2/tools/sceneeditorv5.ui
@@ -1151,6 +1151,9 @@
        <string>Object List</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_6">
+       <item row="0" column="0" colspan="3">
+        <widget class="QListWidget" name="objectList"/>
+       </item>
        <item row="2" column="2">
         <widget class="QToolButton" name="rmObj">
          <property name="enabled">
@@ -1168,6 +1171,19 @@
          </property>
         </widget>
        </item>
+       <item row="2" column="1">
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
        <item row="2" column="0">
         <widget class="QToolButton" name="addObj">
          <property name="toolTip">
@@ -1181,22 +1197,6 @@
            <normaloff>:/icons/ic_add_circle_48px.svg</normaloff>:/icons/ic_add_circle_48px.svg</iconset>
          </property>
         </widget>
-       </item>
-       <item row="0" column="0" colspan="3">
-        <widget class="QListWidget" name="objectList"/>
-       </item>
-       <item row="2" column="1">
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item row="1" column="0" colspan="3">
         <widget class="QLineEdit" name="objectFilter">
@@ -1220,35 +1220,7 @@
        <string>Entity List</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
-       <item row="3" column="3">
-        <widget class="QToolButton" name="downEnt">
-         <property name="toolTip">
-          <string>Moves an entity down</string>
-         </property>
-         <property name="text">
-          <string>D</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../resources.qrc">
-           <normaloff>:/icons/ic_arrow_downward_48px.svg</normaloff>:/icons/ic_arrow_downward_48px.svg</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="2">
-        <widget class="QToolButton" name="upEnt">
-         <property name="toolTip">
-          <string>Moves an entity up</string>
-         </property>
-         <property name="text">
-          <string>U</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../resources.qrc">
-           <normaloff>:/icons/ic_arrow_upward_48px.svg</normaloff>:/icons/ic_arrow_upward_48px.svg</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="5">
+       <item row="2" column="5">
         <widget class="QToolButton" name="rmEnt">
          <property name="enabled">
           <bool>false</bool>
@@ -1265,21 +1237,7 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
-        <widget class="QToolButton" name="addEnt">
-         <property name="toolTip">
-          <string>Adds an entity</string>
-         </property>
-         <property name="text">
-          <string>+</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../resources.qrc">
-           <normaloff>:/icons/ic_add_circle_48px.svg</normaloff>:/icons/ic_add_circle_48px.svg</iconset>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="4">
+       <item row="2" column="4">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -1293,9 +1251,43 @@
         </spacer>
        </item>
        <item row="1" column="0" colspan="6">
+        <widget class="QLineEdit" name="entityFilter">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="inputMask">
+          <string/>
+         </property>
+         <property name="placeholderText">
+          <string>Find entities...</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="6">
         <widget class="QListWidget" name="entityList"/>
        </item>
-       <item row="3" column="1">
+       <item row="2" column="2">
+        <widget class="QToolButton" name="upEnt">
+         <property name="toolTip">
+          <string>Moves an entity up</string>
+         </property>
+         <property name="text">
+          <string>U</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../resources.qrc">
+           <normaloff>:/icons/ic_arrow_upward_48px.svg</normaloff>:/icons/ic_arrow_upward_48px.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="6">
+        <widget class="QPushButton" name="alignEnt">
+         <property name="text">
+          <string>Re-Align Entity Slots</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
         <spacer name="horizontalSpacer_8">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -1308,16 +1300,31 @@
          </property>
         </spacer>
        </item>
-       <item row="2" column="0" colspan="6">
-        <widget class="QLineEdit" name="entityFilter">
+       <item row="2" column="3">
+        <widget class="QToolButton" name="downEnt">
          <property name="toolTip">
-          <string/>
+          <string>Moves an entity down</string>
          </property>
-         <property name="inputMask">
-          <string/>
+         <property name="text">
+          <string>D</string>
          </property>
-         <property name="placeholderText">
-          <string>Find entities...</string>
+         <property name="icon">
+          <iconset resource="../resources.qrc">
+           <normaloff>:/icons/ic_arrow_downward_48px.svg</normaloff>:/icons/ic_arrow_downward_48px.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QToolButton" name="addEnt">
+         <property name="toolTip">
+          <string>Adds an entity</string>
+         </property>
+         <property name="text">
+          <string>+</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../resources.qrc">
+           <normaloff>:/icons/ic_add_circle_48px.svg</normaloff>:/icons/ic_add_circle_48px.svg</iconset>
          </property>
         </widget>
        </item>

--- a/RetroEDv2/tools/sceneproperties/chunkreplaceoptions.cpp
+++ b/RetroEDv2/tools/sceneproperties/chunkreplaceoptions.cpp
@@ -152,6 +152,7 @@ ChunkReplaceOptions::ChunkReplaceOptions(byte gameVer, FormatHelpers::Chunks *ch
                 ui->srcChunkList->item(replacedChunk + i)->setIcon(QPixmap::fromImage(chunks->chunks[replacedChunk + i].getImage((tileList))));
                 ui->dstChunkList->item(replacedChunk + i)->setIcon(QPixmap::fromImage(chunks->chunks[replacedChunk + i].getImage((tileList))));
             }
+            modified = true;
         } else {
             // PrintLog(QString("Single replace mode"));
 

--- a/RetroEDv2/tools/sceneproperties/sceneobjectproperties.cpp
+++ b/RetroEDv2/tools/sceneproperties/sceneobjectproperties.cpp
@@ -74,7 +74,8 @@ void SceneObjectProperties::setupUI(SceneEntity *entity, int entityID, Compilerv
                         QString("An entity already exists with slotID %1.").arg(entity->slotID),
                         QMessageBox::NoButton, this);
                     msgBox->open();
-                    entity->slotID = entity->prevSlot;
+                    entity->slotID         = entity->prevSlot;
+                    entity->gameEntitySlot = entity->prevSlot;
                     flag           = true;
 
                     infoGroup[1]->updateValue();
@@ -82,19 +83,19 @@ void SceneObjectProperties::setupUI(SceneEntity *entity, int entityID, Compilerv
                 }
             }
             byte type = *(byte *)infoGroup[0]->valuePtr;
-            emit typeChanged(entity, type);
+            emit typeChanged(entity, type, true);
         }
         if (!flag)
             entity->prevSlot = entity->slotID;
     });
 
     connect(infoGroup[2], &Property::changed,
-            [this, infoGroup, entity, entityv2, entityv3, entityv4, ver] {
+            [this, infoGroup, entity, entityv2, entityv3, entityv4, ver, entityID] {
                 byte propVal = *(byte *)infoGroup[2]->valuePtr;
 
                 // we set propertyValue via this so the game can run logic on it
                 bool called = false;
-                callRSDKEdit(scnEditor, false, entity->slotID, -1, propVal, &called);
+                callRSDKEdit(scnEditor, false, entityID, -1, propVal, &called);
 
                 if (called) {
                     if (ver == ENGINE_v3)
@@ -117,7 +118,7 @@ void SceneObjectProperties::setupUI(SceneEntity *entity, int entityID, Compilerv
                 for (int i = startGroup; i < properties->propertySet.count(); ++i) {
                     auto &var = entity->variables[i - startGroup];
                     var.value_int32 =
-                        callRSDKEdit(scnEditor, true, entity->slotID, i - startGroup, var.value_int32);
+                        callRSDKEdit(scnEditor, true, entityID, i - startGroup, var.value_int32);
 
                     switch (ver) {
                         case ENGINE_v2: entity->propertyValue = entityv2->propertyValue; break;
@@ -247,7 +248,7 @@ void SceneObjectProperties::setupUI(SceneEntity *entity, int entityID, Compilerv
             for (int i = 3; i < properties->propertySet.count(); ++i) {
                 auto &var = entity->variables[i - 3];
                 var.value_int32 =
-                callRSDKEdit(scnEditor, true, entity->slotID, i - 3, var.value_int32);
+                callRSDKEdit(scnEditor, true, entityID, i - 3, var.value_int32);
 
                 entity->propertyValue = entityv4->propertyValue;
                 for(int v = 0; v < 0xF; v++){
@@ -288,7 +289,7 @@ void SceneObjectProperties::setupUI(SceneEntity *entity, int entityID, Compilerv
             }
         }
 
-        var.value_int32 = callRSDKEdit(scnEditor, true, entity->slotID, v, 0);
+        var.value_int32 = callRSDKEdit(scnEditor, true, entityID, v, 0);
 
         if (aliases.count()) {
             valGroup.append(new Property("enum", aliases, &var.value_int32, Property::INT_MANAGER));

--- a/RetroEDv2/tools/sceneproperties/sceneobjectproperties.hpp
+++ b/RetroEDv2/tools/sceneproperties/sceneobjectproperties.hpp
@@ -33,7 +33,7 @@ public:
     PropertyBrowser *properties = nullptr;
 
 signals:
-    void typeChanged(SceneEntity *entity, byte type);
+    void typeChanged(SceneEntity *entity, byte type, bool keepVals = false);
 
 private:
     Ui::SceneObjectProperties *ui;

--- a/RetroEDv2/tools/sceneproperties/sceneobjectpropertiesv5.cpp
+++ b/RetroEDv2/tools/sceneproperties/sceneobjectpropertiesv5.cpp
@@ -61,7 +61,7 @@ void SceneObjectPropertiesv5::setupUI(SceneEntity *entity)
                 }
             }
             byte type = *(byte *)infoGroup[0]->valuePtr;
-            emit typeChanged(entity, type);
+            emit typeChanged(entity, type, true);
         }
         if (!flag)
             entity->prevSlot = entity->slotID;
@@ -384,7 +384,6 @@ void SceneObjectPropertiesv5::updateUI()
 {
     if (!entityPtr)
         return;
-
     properties->propertySet[0]->subProperties[0]->updateValue();
     properties->propertySet[0]->subProperties[1]->updateValue();
     properties->propertySet[1]->subProperties[0]->updateValue();

--- a/RetroEDv2/tools/sceneproperties/sceneobjectpropertiesv5.hpp
+++ b/RetroEDv2/tools/sceneproperties/sceneobjectpropertiesv5.hpp
@@ -25,7 +25,7 @@ public:
     PropertyBrowser *properties = nullptr;
 
 signals:
-    void typeChanged(SceneEntity *entity, byte type);
+    void typeChanged(SceneEntity *entity, byte type, bool keepVals = false);
 
 private:
     Ui::SceneObjectPropertiesv5 *ui;

--- a/RetroEDv2/tools/sceneproperties/scenetileproperties.cpp
+++ b/RetroEDv2/tools/sceneproperties/scenetileproperties.cpp
@@ -14,6 +14,7 @@ SceneTileProperties::SceneTileProperties(QWidget *parent)
     ui->setupUi(this);
 
     replaceTile  = ui->replaceTile;
+    edit.tileImg = QImage(16,16, QImage::Format_Indexed8);
     ui->tileFrame->layout()->addWidget(&edit);
 }
 
@@ -44,6 +45,7 @@ void SceneTileProperties::setupUI(ushort tid, QList<QImage> &tiles, SceneViewer 
     }
     edit.paintVer            = gameType;
     edit.tileImg             = tileImg;
+    edit.update();
 
     ui->colPlaneA->setChecked(true);
 
@@ -435,7 +437,7 @@ void SceneTileProperties::unsetUI()
     cmaskv1[1] = nullptr;
 
     edit.cmask = cmask[0];
-    edit.tileImg = QImage(0,0);
+    edit.tileImg = QImage(16,16, QImage::Format_Indexed8);
     ui->tileFrame->layout()->removeWidget(&edit);
 }
 
@@ -465,7 +467,6 @@ TileCollisionWidget::TileCollisionWidget(QWidget *parent) : QWidget(parent) { se
 void TileCollisionWidget::paintEvent(QPaintEvent *)
 {
     QPainter p(this);
-
     QRectF rect(0, 0, (qreal)width() / 16, (qreal)height() / 16);
     p.drawImage(QRect(0, 0, width(), height()), tileImg);
 

--- a/RetroEDv2/tools/sceneproperties/scenetileproperties.ui
+++ b/RetroEDv2/tools/sceneproperties/scenetileproperties.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>211</width>
-    <height>651</height>
+    <width>267</width>
+    <height>653</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -35,160 +35,18 @@
    <property name="bottomMargin">
     <number>3</number>
    </property>
+   <item row="12" column="0" colspan="4">
+    <widget class="QPushButton" name="replaceTile">
+     <property name="text">
+      <string>Replace Tile</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="1">
     <widget class="QLabel" name="label_9">
      <property name="text">
       <string>Collision Plane</string>
      </property>
-    </widget>
-   </item>
-   <item row="10" column="0" rowspan="2" colspan="4">
-    <widget class="QWidget" name="RSonicFrame" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>50</height>
-      </size>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <property name="topMargin">
-       <number>3</number>
-      </property>
-      <property name="bottomMargin">
-       <number>3</number>
-      </property>
-      <property name="verticalSpacing">
-       <number>3</number>
-      </property>
-      <item row="0" column="0" colspan="4">
-       <widget class="QLabel" name="label_10">
-        <property name="minimumSize">
-         <size>
-          <width>140</width>
-          <height>13</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Retro-Sonic Properties</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_11">
-        <property name="minimumSize">
-         <size>
-          <width>30</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Col Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="colMode">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>22</height>
-         </size>
-        </property>
-        <item>
-         <property name="text">
-          <string>Floor</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>LWall</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>RWall</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Roof</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>All</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="label_12">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Index</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QComboBox" name="maskIndex">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>22</height>
-         </size>
-        </property>
-        <item>
-         <property name="text">
-          <string>0</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>1</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>2</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>3</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
    <item row="1" column="0" colspan="4">
@@ -198,36 +56,62 @@
      </property>
     </widget>
    </item>
-   <item row="12" column="0" colspan="4">
-    <widget class="QPushButton" name="replaceTile">
+   <item row="13" column="0" colspan="4">
+    <widget class="QPushButton" name="editChunkCol">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string>Replace Tile</string>
+      <string>Edit Chunk Collision</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="tID">
-     <property name="minimumSize">
+   <item row="19" column="0" colspan="4">
+    <widget class="QListWidget" name="tileList">
+     <property name="showDropIndicator" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::DragDrop</enum>
+     </property>
+     <property name="defaultDropAction">
+      <enum>Qt::IgnoreAction</enum>
+     </property>
+     <property name="iconSize">
       <size>
-       <width>60</width>
-       <height>0</height>
+       <width>16</width>
+       <height>16</height>
       </size>
      </property>
-     <property name="text">
-      <string>Tile:</string>
+     <property name="textElideMode">
+      <enum>Qt::ElideNone</enum>
      </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QRadioButton" name="colPlaneB">
-     <property name="minimumSize">
+     <property name="movement">
+      <enum>QListView::Free</enum>
+     </property>
+     <property name="flow">
+      <enum>QListView::LeftToRight</enum>
+     </property>
+     <property name="isWrapping" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="gridSize">
       <size>
-       <width>30</width>
-       <height>0</height>
+       <width>28</width>
+       <height>32</height>
       </size>
      </property>
-     <property name="text">
-      <string>B</string>
+     <property name="viewMode">
+      <enum>QListView::IconMode</enum>
+     </property>
+     <property name="selectionRectVisible">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -685,47 +569,192 @@
      </layout>
     </widget>
    </item>
-   <item row="19" column="0" colspan="4">
-    <widget class="QListWidget" name="tileList">
-     <property name="showDropIndicator" stdset="0">
-      <bool>false</bool>
-     </property>
-     <property name="dragDropMode">
-      <enum>QAbstractItemView::NoDragDrop</enum>
-     </property>
-     <property name="defaultDropAction">
-      <enum>Qt::IgnoreAction</enum>
-     </property>
-     <property name="iconSize">
+   <item row="0" column="2">
+    <widget class="QRadioButton" name="colPlaneA">
+     <property name="minimumSize">
       <size>
-       <width>16</width>
-       <height>16</height>
+       <width>30</width>
+       <height>0</height>
       </size>
      </property>
-     <property name="textElideMode">
-      <enum>Qt::ElideNone</enum>
+     <property name="text">
+      <string>A</string>
      </property>
-     <property name="movement">
-      <enum>QListView::Free</enum>
-     </property>
-     <property name="flow">
-      <enum>QListView::LeftToRight</enum>
-     </property>
-     <property name="isWrapping" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="gridSize">
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="tID">
+     <property name="minimumSize">
       <size>
-       <width>28</width>
-       <height>32</height>
+       <width>60</width>
+       <height>0</height>
       </size>
      </property>
-     <property name="viewMode">
-      <enum>QListView::IconMode</enum>
+     <property name="text">
+      <string>Tile:</string>
      </property>
-     <property name="selectionRectVisible">
-      <bool>true</bool>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QRadioButton" name="colPlaneB">
+     <property name="minimumSize">
+      <size>
+       <width>30</width>
+       <height>0</height>
+      </size>
      </property>
+     <property name="text">
+      <string>B</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" rowspan="2" colspan="4">
+    <widget class="QWidget" name="RSonicFrame" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>50</height>
+      </size>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>3</number>
+      </property>
+      <item row="0" column="0" colspan="4">
+       <widget class="QLabel" name="label_10">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>13</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Retro-Sonic Properties</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_11">
+        <property name="minimumSize">
+         <size>
+          <width>30</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Col Mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="colMode">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>22</height>
+         </size>
+        </property>
+        <item>
+         <property name="text">
+          <string>Floor</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>LWall</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>RWall</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Roof</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>All</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_12">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Index</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QComboBox" name="maskIndex">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>22</height>
+         </size>
+        </property>
+        <item>
+         <property name="text">
+          <string>0</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>1</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>3</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="20" column="0">
@@ -737,6 +766,12 @@
       </sizepolicy>
      </property>
      <property name="minimumSize">
+      <size>
+       <width>256</width>
+       <height>256</height>
+      </size>
+     </property>
+     <property name="maximumSize">
       <size>
        <width>256</width>
        <height>256</height>
@@ -765,35 +800,6 @@
        <number>0</number>
       </property>
      </layout>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QRadioButton" name="colPlaneA">
-     <property name="minimumSize">
-      <size>
-       <width>30</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>A</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0" colspan="4">
-    <widget class="QPushButton" name="editChunkCol">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Edit Chunk Collision</string>
-     </property>
     </widget>
    </item>
   </layout>

--- a/RetroEDv2/tools/sceneproperties/scenetilepropertiesv5.cpp
+++ b/RetroEDv2/tools/sceneproperties/scenetilepropertiesv5.cpp
@@ -10,6 +10,7 @@ SceneTilePropertiesv5::SceneTilePropertiesv5(QWidget *parent)
     ui->setupUi(this);
 
     replaceTile  = ui->replaceTile;
+    edit.tileImg = QImage(16, 16, QImage::Format_Indexed8);
     ui->frame->layout()->addWidget(&edit);
 }
 
@@ -31,6 +32,7 @@ void SceneTilePropertiesv5::setupUI(RSDKv5::TileConfig::CollisionMask *cmA,
     curTile = tile;
     edit.cmask                 = cmask[collisionLyr];
     edit.tileImg               = tileImg;
+    edit.update();
 
     ui->colPlaneA->setChecked(true);
 

--- a/RetroEDv2/tools/sceneproperties/scenetilepropertiesv5.ui
+++ b/RetroEDv2/tools/sceneproperties/scenetilepropertiesv5.ui
@@ -172,7 +172,7 @@
    <item row="12" column="0" colspan="4">
     <widget class="QFrame" name="frame">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
+      <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>


### PR DESCRIPTION
- Added copy and paste for the select tool
- Fix tile collision viewer's random chance of displaying at an incorrect size when loading a stage
- Fix crash on pre-v5 when attempting to pick a tile/chunk from the scene viewer at a location that exceeded the limits of the selected layer
- fix #148 ,#146 and #145
- add #147 for v5