### PR TITLE
Linux: Switched from Wayland to X11

### DIFF
--- a/RetroEDv2/main.cpp
+++ b/RetroEDv2/main.cpp
@@ -88,6 +88,11 @@ QPalette darkPal;
 
 int main(int argc, char *argv[])
 {
+    // Force to use X11 because Wayland is broke in QT 5x
+    #ifdef Q_OS_LINUX
+        qputenv("QT_QPA_PLATFORM", "xcb");
+    #endif
+
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 


### PR DESCRIPTION
Apparently, there's an issue with toolbars in QT5 on Wayland as shown in this video:

https://github.com/user-attachments/assets/b59c2ba5-d5e5-4ee2-88e8-e0098d48d3fa

Basically when moving your mouse at the toolbar it opens another window for some reason with error code of:
`Warning: Wayland does not support QWindow::requestActivate() (:0, )`